### PR TITLE
Mission 3-2

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,5 +23,3 @@ export default tseslint.config(
     rules: { 'prettier/prettier': 'warn' },
   },
 );
-
-// 출처: https://romantech.net/1286 [로맨테크:티스토리]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,18 @@
-export default function App() {
+import { VirtualDom } from '@react/types';
+
+function H1() {
+  return <h1>Hello, React!</h1>;
+}
+
+function H2() {
+  return <h2>Hello, Babel!</h2>;
+}
+
+export default function App(): VirtualDom {
   return (
     <div id="app">
-      <h1>Hello, React Clone!</h1>
-      <h2>Hello, Babel!</h2>
+      <H1 />
+      <H2 />
       <div id="test">
         <p>Hello, Test 1!</p>
         <p>Hello, Test 2!</p>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,11 +16,11 @@ function PositiveCounter() {
   return (
     <div>
       <div>{countA}</div>
-      <button onClick={() => setCountA(count + 1)}>+</button>
-      <button onClick={() => setCountA(count - 1)}>-</button>
+      <button onClick={() => setCountA(countA + 1)}>+</button>
+      <button onClick={() => setCountA(countA - 1)}>-</button>
       <div>{countB}</div>
-      <button onClick={() => setCountB(count2 + 1)}>+</button>
-      <button onClick={() => setCountB(count2 - 1)}>-</button>
+      <button onClick={() => setCountB(countB + 1)}>+</button>
+      <button onClick={() => setCountB(countB - 1)}>-</button>
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,13 +10,17 @@ function H2() {
 }
 
 function PositiveCounter() {
-  const [count, setCount] = useState(0);
+  const [countA, setCountA] = useState(0);
+  const [countB, setCountB] = useState(0);
 
   return (
     <div>
-      <div>{count}</div>
-      <button onClick={() => setCount(count + 1)}>+</button>
-      <button onClick={() => setCount(count - 1)}>-</button>
+      <div>{countA}</div>
+      <button onClick={() => setCountA(count + 1)}>+</button>
+      <button onClick={() => setCountA(count - 1)}>-</button>
+      <div>{countB}</div>
+      <button onClick={() => setCountB(count2 + 1)}>+</button>
+      <button onClick={() => setCountB(count2 - 1)}>-</button>
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { VirtualDom } from '@react/types';
+import { useState } from '@react/useState';
 
 function H1() {
   return <h1>Hello, React!</h1>;
@@ -6,6 +7,30 @@ function H1() {
 
 function H2() {
   return <h2>Hello, Babel!</h2>;
+}
+
+function PositiveCounter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      <div>{count}</div>
+      <button onClick={() => setCount(count + 1)}>+</button>
+      <button onClick={() => setCount(count - 1)}>-</button>
+    </div>
+  );
+}
+
+function NegativeCounter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      <div>{count}</div>
+      <button onClick={() => setCount(count + 1)}>+</button>
+      <button onClick={() => setCount(count - 1)}>-</button>
+    </div>
+  );
 }
 
 export default function App(): VirtualDom {
@@ -17,6 +42,8 @@ export default function App(): VirtualDom {
         <p>Hello, Test 1!</p>
         <p>Hello, Test 2!</p>
       </div>
+      <PositiveCounter />
+      <NegativeCounter />
     </div>
   );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,7 @@
+import { render } from '@react/render';
 import App from './App';
 
 const element = App();
-
 console.log(element);
+
+render(element);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
-import { render } from '@react/render';
+import { render, setPreviousVDom } from '@react/render';
 import App from './App';
 
-const element = App();
-console.log(element);
+const virtualDom = App();
 
-render(element);
+setPreviousVDom(virtualDom);
+render(virtualDom);

--- a/src/react/createElement.ts
+++ b/src/react/createElement.ts
@@ -12,7 +12,7 @@ function createElement(
   ...children: ChildNode[]
 ) {
   const childNodes = children.flat().map((child) => {
-    if (typeof child === 'string') {
+    if (typeof child === 'string' || typeof child === 'number') {
       return {
         type: 'TEXT_ELEMENT',
         props: { nodeValue: child },

--- a/src/react/createElement.ts
+++ b/src/react/createElement.ts
@@ -2,16 +2,16 @@ type ChildNode = ElementNode | null;
 
 interface ElementNode {
   type: string;
-  props: Record<string, any>;
+  props: Record<string, unknown>;
   children: ChildNode[];
 }
 
 function createElement(
   type: string,
-  props: Record<string, any>,
+  props: Record<string, unknown>,
   ...children: ChildNode[]
 ) {
-  const childNodes = children.map((child) => {
+  const childNodes = children.flat().map((child) => {
     if (typeof child === 'string') {
       return {
         type: 'TEXT_ELEMENT',
@@ -24,10 +24,8 @@ function createElement(
 
   return {
     type,
-    props: {
-      ...props,
-      children: childNodes,
-    },
+    props,
+    children: childNodes,
   };
 }
 

--- a/src/react/jsx-runtime.ts
+++ b/src/react/jsx-runtime.ts
@@ -1,21 +1,16 @@
 import createElement from '@react/createElement';
+import { increaseCurrentIndex } from './state';
 
 export function jsx(type: string | Function, props: Record<string, unknown>) {
   const { children, ...restProps } = props;
 
-  if (typeof type === 'string') {
-    return createElement(type, restProps, children);
+  if (typeof type === 'function') {
+    increaseCurrentIndex();
+    return type();
   }
-
-  return type();
+  return createElement(type, restProps, children);
 }
 
 export function jsxs(type: string | Function, props: Record<string, unknown>) {
-  const { children, ...restProps } = props;
-
-  if (typeof type === 'string') {
-    return createElement(type, restProps, children);
-  }
-
-  return type();
+  return jsx(type, props);
 }

--- a/src/react/jsx-runtime.ts
+++ b/src/react/jsx-runtime.ts
@@ -4,7 +4,7 @@ export function jsx(type: string | Function, props: Record<string, unknown>) {
   const { children, ...restProps } = props;
 
   if (typeof type === 'function') {
-    return type();
+    return type({ children, ...restProps });
   }
   return createElement(type, restProps, children);
 }

--- a/src/react/jsx-runtime.ts
+++ b/src/react/jsx-runtime.ts
@@ -1,11 +1,21 @@
 import createElement from '@react/createElement';
 
-export function jsx(elementTag: string, props: Record<string, any>) {
+export function jsx(type: string | Function, props: Record<string, unknown>) {
   const { children, ...restProps } = props;
-  return createElement(elementTag, restProps, children);
+
+  if (typeof type === 'string') {
+    return createElement(type, restProps, children);
+  }
+
+  return type();
 }
 
-export function jsxs(elementTag: string, props: Record<string, any>) {
+export function jsxs(type: string | Function, props: Record<string, unknown>) {
   const { children, ...restProps } = props;
-  return createElement(elementTag, restProps, children);
+
+  if (typeof type === 'string') {
+    return createElement(type, restProps, children);
+  }
+
+  return type();
 }

--- a/src/react/jsx-runtime.ts
+++ b/src/react/jsx-runtime.ts
@@ -1,11 +1,9 @@
 import createElement from '@react/createElement';
-import { increaseCurrentIndex } from './state';
 
 export function jsx(type: string | Function, props: Record<string, unknown>) {
   const { children, ...restProps } = props;
 
   if (typeof type === 'function') {
-    increaseCurrentIndex();
     return type();
   }
   return createElement(type, restProps, children);

--- a/src/react/render.ts
+++ b/src/react/render.ts
@@ -1,4 +1,8 @@
 import { VirtualDom } from './types';
+import App from '../App';
+import { resetCurrentIndex } from './state';
+
+let previousVDom: VirtualDom | null = null;
 
 export function render(virtualDom: VirtualDom) {
   const app = document.querySelector('#app')!;
@@ -8,9 +12,32 @@ export function render(virtualDom: VirtualDom) {
   });
 }
 
+export function rerender() {
+  resetCurrentIndex(); // 상태 인덱스 초기화
+  const currentVDom = App(); // 루트 컴포넌트 다시 호출
+  const app = document.querySelector('#app')!;
+
+  if (previousVDom) {
+    updateChildren(
+      app as HTMLElement,
+      previousVDom.children,
+      currentVDom.children,
+    );
+  } else {
+    resetDom();
+    render(currentVDom);
+  }
+
+  setPreviousVDom(currentVDom); // 이전 VDOM 저장
+}
+
 export function resetDom() {
   const app = document.querySelector('#app')!;
   app.innerHTML = '';
+}
+
+export function setPreviousVDom(vDom: VirtualDom) {
+  previousVDom = vDom;
 }
 
 function commitDom(vdom: VirtualDom, $parent: HTMLElement) {
@@ -37,4 +64,79 @@ function commitDom(vdom: VirtualDom, $parent: HTMLElement) {
   children.forEach((childVDom) => {
     commitDom(childVDom, $newElement);
   });
+}
+
+function updateDom(
+  $parent: HTMLElement,
+  prevNode: VirtualDom,
+  currentNode: VirtualDom,
+  index = 0,
+) {
+  const existingElement = $parent.childNodes[index] as HTMLElement | null;
+
+  // 1. 새 노드가 추가되었을 경우
+  if (!prevNode) {
+    console.log('#1');
+    commitDom(currentNode, $parent);
+    return;
+  }
+
+  // 2. 노드가 삭제되었을 경우
+  if (!currentNode) {
+    console.log('#2');
+    if (existingElement) $parent.removeChild(existingElement);
+    return;
+  }
+
+  // 3. 타입이 다르면 교체
+  if (prevNode.type !== currentNode.type) {
+    console.log('#3');
+    commitDom(currentNode, $parent);
+    return;
+  }
+
+  // 4. 속성 업데이트
+  updateAttributes(existingElement!, prevNode.props, currentNode.props);
+
+  // 5. 자식 요소 업데이트
+  updateChildren(existingElement!, prevNode.children, currentNode.children);
+}
+
+function updateAttributes(
+  element: HTMLElement,
+  prevProps: Record<string, unknown>,
+  currentProps: Record<string, unknown>,
+) {
+  // 모든 속성 검사
+  const allProps = { ...prevProps, ...currentProps };
+
+  for (const key in allProps) {
+    if (currentProps[key] === undefined) {
+      element.removeAttribute(key);
+    } else if (prevProps[key] !== currentProps[key]) {
+      if (key === 'nodeValue') {
+        // TEXT_ELEMENT 처리
+        element.textContent = String(currentProps[key]);
+      } else if (key.startsWith('on')) {
+        // 이벤트 처리
+        const eventType = key.slice(2).toLowerCase();
+        element.removeEventListener(eventType, prevProps[key] as EventListener);
+        element.addEventListener(eventType, currentProps[key] as EventListener);
+      } else {
+        element.setAttribute(key, String(currentProps[key]));
+      }
+    }
+  }
+}
+
+function updateChildren(
+  $parent: HTMLElement,
+  prevChildren: VirtualDom[],
+  currentNode: VirtualDom[],
+) {
+  const maxLen = Math.max(prevChildren.length, currentNode.length);
+
+  for (let i = 0; i < maxLen; i++) {
+    updateDom($parent, prevChildren[i], currentNode[i], i);
+  }
 }

--- a/src/react/render.ts
+++ b/src/react/render.ts
@@ -6,6 +6,11 @@ export function render(virtualDom: VirtualDom) {
   commitDom(virtualDom, app as HTMLElement);
 }
 
+export function resetDom() {
+  const app = document.querySelector('#app')!;
+  app.innerHTML = '';
+}
+
 function commitDom(vdom: VirtualDom, $parentElement: HTMLElement) {
   const { type, props, children } = vdom;
 

--- a/src/react/render.ts
+++ b/src/react/render.ts
@@ -23,7 +23,11 @@ function commitDom(vdom: VirtualDom, $parentElement: HTMLElement) {
   const $newElement = document.createElement(type);
 
   Object.entries(props).forEach(([key, value]) => {
-    $newElement.setAttribute(key, value as string);
+    if (key === 'onClick') {
+      $newElement.addEventListener('click', value);
+    } else {
+      $newElement.setAttribute(key, value as string);
+    }
   });
 
   $parentElement.appendChild($newElement);

--- a/src/react/render.ts
+++ b/src/react/render.ts
@@ -3,7 +3,9 @@ import { VirtualDom } from './types';
 export function render(virtualDom: VirtualDom) {
   const app = document.querySelector('#app')!;
 
-  commitDom(virtualDom, app as HTMLElement);
+  virtualDom.children.forEach((childVDom) => {
+    commitDom(childVDom, app as HTMLElement);
+  });
 }
 
 export function resetDom() {
@@ -11,12 +13,12 @@ export function resetDom() {
   app.innerHTML = '';
 }
 
-function commitDom(vdom: VirtualDom, $parentElement: HTMLElement) {
+function commitDom(vdom: VirtualDom, $parent: HTMLElement) {
   const { type, props, children } = vdom;
 
   if (type === 'TEXT_ELEMENT') {
     const { nodeValue } = props;
-    $parentElement.innerText = nodeValue as string;
+    $parent.innerText = nodeValue as string;
     return;
   }
 
@@ -30,7 +32,7 @@ function commitDom(vdom: VirtualDom, $parentElement: HTMLElement) {
     }
   });
 
-  $parentElement.appendChild($newElement);
+  $parent.appendChild($newElement);
 
   children.forEach((childVDom) => {
     commitDom(childVDom, $newElement);

--- a/src/react/render.ts
+++ b/src/react/render.ts
@@ -1,0 +1,29 @@
+import { VirtualDom } from './types';
+
+export function render(virtualDom: VirtualDom) {
+  const app = document.querySelector('#app')!;
+
+  commitDom(virtualDom, app as HTMLElement);
+}
+
+function commitDom(vdom: VirtualDom, $parentElement: HTMLElement) {
+  const { type, props, children } = vdom;
+
+  if (type === 'TEXT_ELEMENT') {
+    const { nodeValue } = props;
+    $parentElement.innerText = nodeValue as string;
+    return;
+  }
+
+  const $newElement = document.createElement(type);
+
+  Object.entries(props).forEach(([key, value]) => {
+    $newElement.setAttribute(key, value as string);
+  });
+
+  $parentElement.appendChild($newElement);
+
+  children.forEach((childVDom) => {
+    commitDom(childVDom, $newElement);
+  });
+}

--- a/src/react/state.ts
+++ b/src/react/state.ts
@@ -1,0 +1,10 @@
+export const stateStore: Record<number, unknown> = {}; // 상태 저장소
+export let currentIndex = 0; // 현재 컴포넌트의 상태 인덱스
+
+export function increaseCurrentIndex() {
+  currentIndex += 1;
+}
+
+export function resetCurrentIndex() {
+  currentIndex = 0;
+}

--- a/src/react/syntheticEvent.ts
+++ b/src/react/syntheticEvent.ts
@@ -1,0 +1,71 @@
+export type Listener = (event: SyntheticEvent) => void;
+
+type SyntheticEvent = {
+  nativeEvent: Event;
+  type: string;
+  target: EventTarget | null;
+  currentTarget: EventTarget | null;
+  isPropagationStopped: boolean;
+  stopPropagation: () => void;
+  preventDefault: () => void;
+};
+
+const createSyntheticEvent = (nativeEvent: Event): SyntheticEvent => {
+  let isPropagationStopped = false;
+
+  return {
+    nativeEvent,
+    type: nativeEvent.type,
+    target: nativeEvent.target,
+    currentTarget: nativeEvent.currentTarget,
+    isPropagationStopped,
+    stopPropagation: () => {
+      isPropagationStopped = true;
+    },
+    preventDefault: () => {
+      nativeEvent.preventDefault();
+    },
+  };
+};
+
+// 이벤트 관리 객체
+export const eventRegistry = new Map<string, Map<Element, Listener>>();
+
+export const registerEvent = (
+  eventType: string,
+  element: Element,
+  listener: Listener,
+) => {
+  console.log(`Registering event: ${eventType} on`, element);
+
+  if (!eventRegistry.has(eventType)) {
+    eventRegistry.set(eventType, new Map());
+    document.addEventListener(eventType, dispatchEvent);
+  }
+  eventRegistry.get(eventType)!.set(element, listener);
+};
+
+export const unregisterEvent = (eventType: string, element: Element) => {
+  console.log(`Unregistering event: ${eventType} from`, element);
+
+  eventRegistry.get(eventType)?.delete(element);
+};
+
+// 이벤트 실행 (루트에서 처리)
+const dispatchEvent = (nativeEvent: Event) => {
+  console.log(`Dispatching event: ${nativeEvent.type} on`, nativeEvent.target);
+
+  const syntheticEvent = createSyntheticEvent(nativeEvent);
+  let currentTarget = nativeEvent.target as HTMLElement | null;
+
+  while (currentTarget && !syntheticEvent.isPropagationStopped) {
+    const listeners = eventRegistry.get(nativeEvent.type);
+    if (listeners?.has(currentTarget)) {
+      console.log(`Executing handler for`, currentTarget);
+
+      syntheticEvent.currentTarget = currentTarget;
+      listeners.get(currentTarget)!(syntheticEvent);
+    }
+    currentTarget = currentTarget.parentElement;
+  }
+};

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -1,0 +1,5 @@
+export interface VirtualDom {
+  type: string;
+  props: Record<string, unknown>;
+  children: VirtualDom[];
+}

--- a/src/react/useState.ts
+++ b/src/react/useState.ts
@@ -1,5 +1,4 @@
-import App from '../App';
-import { render, resetDom } from './render';
+import { rerender } from './render';
 import {
   currentIndex,
   stateStore,
@@ -28,7 +27,5 @@ export function useState<T>(initialValue: T): [T, (newValue: T) => void] {
 
 function rerenderApp() {
   resetCurrentIndex(); // 렌더링 시작 시 상태 인덱스 초기화
-  const vdom = App(); // 루트 컴포넌트 다시 호출
-  resetDom();
-  render(vdom); // 화면 다시 렌더링
+  rerender();
 }

--- a/src/react/useState.ts
+++ b/src/react/useState.ts
@@ -7,21 +7,20 @@ import {
   increaseCurrentIndex,
 } from './state';
 
-export function useState(initialValue: any) {
+export function useState<T>(initialValue: T): [T, (newValue: T) => void] {
   if (stateStore[currentIndex] === undefined) {
     stateStore[currentIndex] = initialValue; // 현재 인덱스의 상태가 없으면 초기값을 설정
   }
 
   const capturedIndex = currentIndex;
 
-  const setState = (newValue: any) => {
+  const setState = (newValue: T) => {
     stateStore[capturedIndex] = newValue; // 상태 업데이트
-    console.log(capturedIndex, stateStore);
 
     rerenderApp(); // 앱을 전체 렌더링
   };
 
-  const value = stateStore[capturedIndex]; // 현재 상태와 상태 업데이트 함수를 반환
+  const value = stateStore[capturedIndex] as T; // 현재 상태와 상태 업데이트 함수를 반환
   increaseCurrentIndex();
 
   return [value, setState];

--- a/src/react/useState.ts
+++ b/src/react/useState.ts
@@ -1,0 +1,27 @@
+import App from '../App';
+import { render, resetDom } from './render';
+import { currentIndex, stateStore, resetCurrentIndex } from './state';
+
+export function useState(initialValue: any) {
+  if (stateStore[currentIndex] === undefined) {
+    stateStore[currentIndex] = initialValue; // 현재 인덱스의 상태가 없으면 초기값을 설정
+  }
+
+  const capturedIndex = currentIndex;
+
+  const setState = (newValue: any) => {
+    stateStore[capturedIndex] = newValue; // 상태 업데이트
+
+    rerenderApp(); // 앱을 전체 렌더링
+  };
+
+  const value = stateStore[capturedIndex]; // 현재 상태와 상태 업데이트 함수를 반환
+  return [value, setState];
+}
+
+function rerenderApp() {
+  resetCurrentIndex(); // 렌더링 시작 시 상태 인덱스 초기화
+  const vdom = App(); // 루트 컴포넌트 다시 호출
+  resetDom();
+  render(vdom); // 화면 다시 렌더링
+}

--- a/src/react/useState.ts
+++ b/src/react/useState.ts
@@ -1,6 +1,11 @@
 import App from '../App';
 import { render, resetDom } from './render';
-import { currentIndex, stateStore, resetCurrentIndex } from './state';
+import {
+  currentIndex,
+  stateStore,
+  resetCurrentIndex,
+  increaseCurrentIndex,
+} from './state';
 
 export function useState(initialValue: any) {
   if (stateStore[currentIndex] === undefined) {
@@ -11,11 +16,14 @@ export function useState(initialValue: any) {
 
   const setState = (newValue: any) => {
     stateStore[capturedIndex] = newValue; // 상태 업데이트
+    console.log(capturedIndex, stateStore);
 
     rerenderApp(); // 앱을 전체 렌더링
   };
 
   const value = stateStore[capturedIndex]; // 현재 상태와 상태 업데이트 함수를 반환
+  increaseCurrentIndex();
+
   return [value, setState];
 }
 


### PR DESCRIPTION
### Changes
- SyntheticEvent 시스템 구현
- 기존 render과 rerender 함수에 적용

### Notes for Reviewers
이 PR에서는 SyntheticEvent 시스템을 구현하고 기존 render 및 rerender 함수에 적용했습니다.

- SyntheticEvent 구현
  - 네이티브 이벤트를 감싸는 SyntheticEvent 객체를 생성
  - 이벤트를 전역적으로 관리하기 위해 registerEvent, unregisterEvent, dispatchEvent 함수를 구현

        registerEvent: 특정 요소에 이벤트를 등록하며, 루트(document 레벨)에서 이벤트를 감지
        unregisterEvent: 필요 없는 이벤트 리스너를 제거
        dispatchEvent: 루트에서 이벤트를 감지하고, event.target을 이용해 적절한 핸들러를 실행
- 기존 render 및 rerender에 적용

  - commitDom에서 registerEvent를 사용하여 중앙에서 관리하도록 변경
  - updateAttributes에서 onClick 같은 이벤트 속성을 처리할 때 registerEvent와 unregisterEvent를 활용하도록 수정


### Result
![Jan-31-2025 19-35-52](https://github.com/user-attachments/assets/1ba31cc3-29cc-49ef-8d11-1f16b78253d4)


